### PR TITLE
Adds LoggingFilterSwitch

### DIFF
--- a/src/Serilog.Filters.Expressions/Filters/Expressions/LoggingFilterSwitch.cs
+++ b/src/Serilog.Filters.Expressions/Filters/Expressions/LoggingFilterSwitch.cs
@@ -1,0 +1,93 @@
+﻿// Copyright 2013-2015 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Core;
+using Serilog.Events;
+using System;
+
+namespace Serilog.Filters.Expressions
+{
+    /// <summary>
+    /// A log event filter that can be modified at runtime.
+    /// </summary>
+    public class LoggingFilterSwitch : ILogEventFilter
+    {
+        // Reference assignments are atomic. While this class makes
+        // no attempt to synchronize Expression, ToString(), and IsIncluded(),
+        // for any observer, this at least ensures they won't be permanently out-of-sync for
+        // all observers.
+        volatile Tuple<string, Func<LogEvent, object>> _filter;
+
+        /// <summary>
+        /// Construct a <see cref="LoggingFilterSwitch"/>, optionally initialized
+        /// with the <paramref name="expression"/>.
+        /// </summary>
+        /// <param name="expression">A filter expression against which log events will be tested.
+        /// Only expressions that evaluate to <c>true</c> are included
+        /// by the filter. A <c>null</c> expression will accept all
+        /// events.</param>
+        public LoggingFilterSwitch(string expression = null)
+        {
+            Expression = expression;
+        }
+
+        /// <summary>
+        /// A filter expression against which log events will be tested.
+        /// Only expressions that evaluate to <c>true</c> are included
+        /// by the filter. A <c>null</c> expression will accept all
+        /// events.
+        /// </summary>
+        public string Expression
+        {
+            get
+            {
+                var filter = _filter;
+                return filter?.Item1;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    _filter = null;
+                }
+                else
+                {
+                    _filter = new Tuple<string, Func<LogEvent, object>>(
+                        value,
+                        FilterLanguage.CreateFilter(value));
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public bool IsEnabled(LogEvent logEvent)
+        {
+            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+
+            var filter = _filter;
+
+            if (filter == null)
+                return true;
+
+            return true.Equals(filter.Item2(logEvent));
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            var filter = _filter;
+            return filter?.Item1 ?? "";
+        }
+    }
+}

--- a/src/Serilog.Filters.Expressions/LoggerFilterConfigurationExtensions.cs
+++ b/src/Serilog.Filters.Expressions/LoggerFilterConfigurationExtensions.cs
@@ -38,5 +38,20 @@ namespace Serilog
             var compiled = FilterLanguage.CreateFilter(expression);
             return loggerFilterConfiguration.ByExcluding(e => true.Equals(compiled(e)));
         }
+
+        /// <summary>
+        /// Use a <see cref="LoggingFilterSwitch"/> to dynamically control filtering.
+        /// </summary>
+        /// <param name="loggerFilterConfiguration">Filter configuration.</param>
+        /// <param name="switch">A <see cref="LoggingFilterSwitch"/> that can be used to dynamically control
+        /// log filtering.</param>
+        /// <returns>The underlying <see cref="LoggerConfiguration"/>.</returns>
+        public static LoggerConfiguration ControlledBy(this LoggerFilterConfiguration loggerFilterConfiguration, LoggingFilterSwitch @switch)
+        {
+            if (loggerFilterConfiguration == null) throw new ArgumentNullException(nameof(loggerFilterConfiguration));
+            if (@switch == null) throw new ArgumentNullException(nameof(@switch));
+
+            return loggerFilterConfiguration.With(@switch);
+        }
     }
 }

--- a/test/Serilog.Filters.Expressions.Tests/FilterExpressionCompilerTests.cs
+++ b/test/Serilog.Filters.Expressions.Tests/FilterExpressionCompilerTests.cs
@@ -104,6 +104,7 @@ namespace Serilog.Filters.Expressions.Tests
                 Some.InformationEvent("Checking out {@Cart}", new { Total = 20 }),
                 Some.InformationEvent("Checking out {@Cart}", new { Total = 5 }));
         }
+
         static void AssertFiltering(string expression, LogEvent match, params LogEvent[] noMatches)
         {
             var sink = new CollectingSink();

--- a/test/Serilog.Filters.Expressions.Tests/LoggingFilterSwitchTests.cs
+++ b/test/Serilog.Filters.Expressions.Tests/LoggingFilterSwitchTests.cs
@@ -1,0 +1,43 @@
+﻿using Serilog.Filters.Expressions.Tests.Support;
+using System.Linq;
+using Xunit;
+
+namespace Serilog.Filters.Expressions.Tests
+{
+    public class LoggingFilterSwitchTests
+    {
+        [Fact]
+        public void WhenTheFilterExpressionIsModifiedTheFilterChanges()
+        {
+            var @switch = new LoggingFilterSwitch();
+            var sink = new CollectingSink();
+
+            var log = new LoggerConfiguration()
+                .Filter.ControlledBy(@switch)
+                .WriteTo.Sink(sink)
+                .CreateLogger();
+
+            var v11 = Some.InformationEvent("Adding {Volume} L", 11);
+
+            log.Write(v11);
+            Assert.Same(v11, sink.SingleEvent);
+            sink.Events.Clear();
+
+            @switch.Expression = "Volume > 12";
+
+            log.Write(v11);
+            Assert.Equal(0, sink.Events.Count);
+
+            @switch.Expression = "Volume > 10";
+
+            log.Write(v11);
+            Assert.Same(v11, sink.SingleEvent);
+            sink.Events.Clear();
+
+            @switch.Expression = null;
+
+            log.Write(v11);
+            Assert.Same(v11, sink.SingleEvent);
+        }
+    }
+}


### PR DESCRIPTION
Runtime filtering control.

```csharp
var @switch = new LoggingFilterSwitch();
var sink = new CollectingSink();

var log = new LoggerConfiguration()
    .Filter.ControlledBy(@switch)
    .WriteTo.Sink(sink)
    .CreateLogger();

// Written
log.Information("Adding {Volume} L", 11);

@switch.Expression = "Volume > 12";

// Not written
log.Information("Adding {Volume} L", 11);
```
