### PR TITLE
Update version of Superpower to 1.0.1

### DIFF
--- a/src/Serilog.Filters.Expressions/project.json
+++ b/src/Serilog.Filters.Expressions/project.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "Serilog": "2.3.0",
-    "Superpower": "1.0.0"
+    "Superpower": "1.0.1"
   },
   "buildOptions": {
     "keyFile": "../../assets/Serilog.snk",


### PR DESCRIPTION
Hi again, 

It's about dependencies, that Superpower 1.0.0 brings because of .NET Standart =)