### PR TITLE
Remove direct references to Serilog and Superpower

### DIFF
--- a/example/Sample/project.json
+++ b/example/Sample/project.json
@@ -10,9 +10,7 @@
       "version": "1.0.1"
     },
     "Serilog.Filters.Expressions": {"target": "project"},
-    "Serilog": "2.3.0",
-    "Serilog.Sinks.Literate": "2.0.0",
-    "Superpower": "1.0.0"
+    "Serilog.Sinks.Literate": "2.0.0"
   },
 
   "frameworks": {


### PR DESCRIPTION
Hi,

Previously I missed a reference to Superpower 1.0.0 in Sample project, that causes some warnings in build process.

> warn : Detected package downgrade: Superpower from 1.0.1 to 1.0.0 
> warn :  Sample (>= 1.0.0) -> Serilog.Filters.Expressions  -> Superpower (>= 1.0.1) 
> warn :  Sample (>= 1.0.0) -> Superpower (>= 1.0.0)

This commit fixes this. Sorry for that :(