### PR TITLE
Remove non-thread-safe static tokenizer

### DIFF
--- a/src/Serilog.Filters.Expressions/Filters/Expressions/Parsing/FilterExpressionParser.cs
+++ b/src/Serilog.Filters.Expressions/Filters/Expressions/Parsing/FilterExpressionParser.cs
@@ -6,8 +6,6 @@ namespace Serilog.Filters.Expressions.Parsing
 {
     static class FilterExpressionParser
     {
-        static readonly FilterExpressionTokenizer Tokenizer = new FilterExpressionTokenizer();
-
         public static FilterExpression Parse(string filterExpression)
         {
             FilterExpression root;
@@ -22,7 +20,8 @@ namespace Serilog.Filters.Expressions.Parsing
         {
             if (filterExpression == null) throw new ArgumentNullException(nameof(filterExpression));
 
-            var tokenList = Tokenizer.TryTokenize(filterExpression);
+            var tokenizer = new FilterExpressionTokenizer();
+            var tokenList = tokenizer.TryTokenize(filterExpression);
             
             if (!tokenList.HasValue)
             {


### PR DESCRIPTION
Superpower `Tokenizer`s [are stateful](https://github.com/datalust/superpower/issues/12) - the `Previous` property tracks the last-yielded token.

We use this here to decide whether `/` is a division operator or the start of a `/regular expression/`:

https://github.com/serilog/serilog-filters-expressions/blob/dev/src/Serilog.Filters.Expressions/Filters/Expressions/Parsing/FilterExpressionTokenizer.cs#L144

This makes `Tokenizer` instances non-thread-safe, so we shouldn't be sharing a single instance between parses.

