### PR TITLE
Fix evaluation of filters that return structure or sequence values

### DIFF
--- a/src/Serilog.Filters.Expressions/Filters/Expressions/Runtime/Representation.cs
+++ b/src/Serilog.Filters.Expressions/Filters/Expressions/Runtime/Representation.cs
@@ -44,12 +44,12 @@ namespace Serilog.Filters.Expressions.Runtime
 
             var sequence = internalValue as SequenceValue;
             if (sequence != null)
-                return sequence.Elements.Select(Expose).ToArray();
+                return sequence.Elements.Select(ExposeOrRepresent).ToArray();
 
             var structure = internalValue as StructureValue;
             if (structure != null)
             {
-                var r = structure.Properties.ToDictionary(p => p.Name, p => Expose(p.Value));
+                var r = structure.Properties.ToDictionary(p => p.Name, p => ExposeOrRepresent(p.Value));
                 if (structure.TypeTag != null)
                     r["$type"] = structure.TypeTag;
                 return r;
@@ -58,10 +58,21 @@ namespace Serilog.Filters.Expressions.Runtime
             var dictionary = internalValue as DictionaryValue;
             if (dictionary != null)
             {
-                return dictionary.Elements.ToDictionary(p => Expose(p.Key), p => Expose(p.Value));
+                return dictionary.Elements.ToDictionary(p => ExposeOrRepresent(p.Key), p => ExposeOrRepresent(p.Value));
             }
 
             return internalValue;
+        }
+
+        static object ExposeOrRepresent(object internalValue)
+        {
+            if (internalValue is Undefined)
+                return null;
+
+            if (internalValue is ScalarValue sv)
+                return Represent(sv);
+
+            return Expose(internalValue);
         }
 
         public static LogEventPropertyValue Recapture(object value)

--- a/test/Serilog.Filters.Expressions.Tests/FilterExpressionCompilerTests.cs
+++ b/test/Serilog.Filters.Expressions.Tests/FilterExpressionCompilerTests.cs
@@ -1,4 +1,5 @@
-﻿using Serilog.Events;
+﻿using System.Collections.Generic;
+using Serilog.Events;
 using Serilog.Filters.Expressions.Tests.Support;
 using System.Linq;
 using Xunit;
@@ -149,6 +150,16 @@ namespace Serilog.Filters.Expressions.Tests
 
             Assert.Single(sink.Events);
             Assert.Same(match, sink.Events.Single());
+        }
+
+        [Fact]
+        public void StructuresAreExposedAsDictionaries()
+        {
+            var evt = Some.InformationEvent("{@Person}", new { Name = "nblumhardt" });
+            var expr = FilterLanguage.CreateFilter("Person");
+            var val = expr(evt);
+            var dict = Assert.IsType<Dictionary<string, object>>(val);
+            Assert.Equal("nblumhardt", dict["Name"]);
         }
     }
 }


### PR DESCRIPTION
The `FilterLanguage.CreateFilter()` function currently fails if the filter returns a structure or sequence value, despite the presence of some code intended to convert these into dictionaries or arrays.
