### PR TITLE
Support for conditional sinks/enrichers

### DIFF
--- a/serilog-filters-expressions.sln.DotSettings
+++ b/serilog-filters-expressions.sln.DotSettings
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enricher/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=nblumhardt/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serilog/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Serilog.Filters.Expressions/LoggerEnrichmentConfigurationExtensions.cs
+++ b/src/Serilog.Filters.Expressions/LoggerEnrichmentConfigurationExtensions.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2019 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Serilog.Configuration;
+using Serilog.Filters.Expressions;
+
+namespace Serilog
+{
+    /// <summary>
+    /// Extends logger enrichment configuration with methods for filtering with expressions.
+    /// </summary>
+    public static class LoggerEnrichmentConfigurationExtensions
+    {
+        /// <summary>
+        /// Write to a sink only when <paramref name="expression" /> evaluates to <c>true</c>.
+        /// </summary>
+        /// <param name="loggerEnrichmentConfiguration">Enrichment configuration.</param>
+        /// <param name="expression">An expression that evaluates to <c>true</c> when the supplied
+        /// <see cref="T:Serilog.Events.LogEvent" /> should be enriched.</param>
+        /// <param name="configureEnricher">An action that configures the wrapped enricher.</param>
+        /// <returns>Configuration object allowing method chaining.</returns>
+        /// <returns>The underlying <see cref="LoggerConfiguration"/>.</returns>
+        public static  LoggerConfiguration When(
+            this LoggerEnrichmentConfiguration loggerEnrichmentConfiguration,
+            string expression,
+            Action<LoggerEnrichmentConfiguration> configureEnricher)
+        {
+            if (loggerEnrichmentConfiguration == null) throw new ArgumentNullException(nameof(loggerEnrichmentConfiguration));
+            if (expression == null) throw new ArgumentNullException(nameof(expression));
+            if (configureEnricher == null) throw new ArgumentNullException(nameof(configureEnricher));
+
+            var compiled = FilterLanguage.CreateFilter(expression);
+            return loggerEnrichmentConfiguration.When(e => true.Equals(compiled(e)), configureEnricher);
+        }
+    }
+}

--- a/src/Serilog.Filters.Expressions/LoggerFilterConfigurationExtensions.cs
+++ b/src/Serilog.Filters.Expressions/LoggerFilterConfigurationExtensions.cs
@@ -5,7 +5,7 @@ using System;
 namespace Serilog
 {
     /// <summary>
-    /// Extends logger configuration with methods for filtering with expressions.
+    /// Extends logger filter configuration with methods for filtering with expressions.
     /// </summary>
     public static class LoggerFilterConfigurationExtensions
     {

--- a/src/Serilog.Filters.Expressions/LoggerSinkConfigurationExtensions.cs
+++ b/src/Serilog.Filters.Expressions/LoggerSinkConfigurationExtensions.cs
@@ -1,0 +1,49 @@
+﻿// Copyright 2019 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Serilog.Configuration;
+using Serilog.Filters.Expressions;
+
+namespace Serilog
+{
+    /// <summary>
+    /// Extends logger sink configuration with methods for filtering with expressions.
+    /// </summary>
+    public static class LoggerSinkConfigurationExtensions
+    {
+        /// <summary>
+        /// Write to a sink only when <paramref name="expression" /> evaluates to <c>true</c>.
+        /// </summary>
+        /// <param name="loggerSinkConfiguration">Sink configuration.</param>
+        /// <param name="expression">An expression that evaluates to <c>true</c> when the
+        /// supplied <see cref="T:Serilog.Events.LogEvent" />
+        /// should be written to the configured sink.</param>
+        /// <param name="configureSink">An action that configures the wrapped sink.</param>
+        /// <returns>Configuration object allowing method chaining.</returns>
+        /// <returns>The underlying <see cref="LoggerConfiguration"/>.</returns>
+        public static  LoggerConfiguration Conditional(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            string expression,
+            Action<LoggerSinkConfiguration> configureSink)
+        {
+            if (loggerSinkConfiguration == null) throw new ArgumentNullException(nameof(loggerSinkConfiguration));
+            if (expression == null) throw new ArgumentNullException(nameof(expression));
+            if (configureSink == null) throw new ArgumentNullException(nameof(configureSink));
+
+            var compiled = FilterLanguage.CreateFilter(expression);
+            return loggerSinkConfiguration.Conditional(e => true.Equals(compiled(e)), configureSink);
+        }
+    }
+}

--- a/src/Serilog.Filters.Expressions/Serilog.Filters.Expressions.csproj
+++ b/src/Serilog.Filters.Expressions/Serilog.Filters.Expressions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Expression-based event filtering for Serilog.</Description>
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0-dev-*" />
+    <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Superpower" Version="2.3.0" />
   </ItemGroup>
 

--- a/src/Serilog.Filters.Expressions/Serilog.Filters.Expressions.csproj
+++ b/src/Serilog.Filters.Expressions/Serilog.Filters.Expressions.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Expression-based event filtering for Serilog.</Description>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>net4.5;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net4.5;netstandard1.5;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Filters.Expressions</AssemblyName>
@@ -24,8 +24,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.7.1" />
-    <PackageReference Include="Superpower" Version="2.0.0" />
+    <PackageReference Include="Serilog" Version="2.9.0-dev-*" />
+    <PackageReference Include="Superpower" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net4.5' ">

--- a/test/Serilog.Filters.Expressions.Tests/ConfigurationTests.cs
+++ b/test/Serilog.Filters.Expressions.Tests/ConfigurationTests.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using Serilog.Filters.Expressions.Tests.Support;
+using Xunit;
+
+namespace Serilog.Filters.Expressions.Tests
+{
+    public class ConfigurationTests
+    {
+        [Fact]
+        public void ExpressionsControlConditionalSinks()
+        {
+            var sink = new CollectingSink();
+            var logger = new LoggerConfiguration()
+                .WriteTo.Conditional("A = 1 or A = 2", wt => wt.Sink(sink))
+                .CreateLogger();
+
+            foreach (var a in Enumerable.Range(0, 5))
+                logger.Information("{A}", a);
+
+            Assert.Equal(2, sink.Events.Count);
+        }
+
+        [Fact]
+        public void ExpressionsControlConditionalEnrichment()
+        {
+            var sink = new CollectingSink();
+            var logger = new LoggerConfiguration()
+                .Enrich.When("A = 1 or A = 2", e => e.WithProperty("B", 1))
+                .WriteTo.Sink(sink)
+                .CreateLogger();
+
+            foreach (var a in Enumerable.Range(0, 5))
+                logger.Information("{A}", a);
+
+            Assert.Equal(2, sink.Events.Count(e => e.Properties.ContainsKey("B")));
+        }
+    }
+}


### PR DESCRIPTION
From the tests:

```csharp
[Fact]
public void ExpressionsControlConditionalSinks()
{
    var sink = new CollectingSink();
    var logger = new LoggerConfiguration()
        .WriteTo.Conditional("A = 1 or A = 2", wt => wt.Sink(sink))
        .CreateLogger();

    foreach (var a in Enumerable.Range(0, 5))
        logger.Information("{A}", a);

    Assert.Equal(2, sink.Events.Count);
}

[Fact]
public void ExpressionsControlConditionalEnrichment()
{
    var sink = new CollectingSink();
    var logger = new LoggerConfiguration()
        .Enrich.When("A = 1 or A = 2", e => e.WithProperty("B", 1))
        .WriteTo.Sink(sink)
        .CreateLogger();

    foreach (var a in Enumerable.Range(0, 5))
        logger.Information("{A}", a);

    Assert.Equal(2, sink.Events.Count(e => e.Properties.ContainsKey("B")));
}
```

Requires Serilog 2.9.